### PR TITLE
Abandon original image metadata and bake rotation into the scaled image

### DIFF
--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerImageUtil.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerImageUtil.m
@@ -68,13 +68,17 @@
       }
     }
   }
+  
+  UIImageOrientation orientation = [image imageOrientation];
 
   // Scaling the image always rotate itself based on the current imageOrientation of the original
   // Image. Set to orientationUp for the orignal image before scaling, so the scaled image doesn't
   // mess up with the pixels.
   UIImage *imageToScale = [UIImage imageWithCGImage:image.CGImage
                                               scale:1
-                                        orientation:UIImageOrientationUp];
+                                        orientation:orientation];
+  
+
 
   // The image orientation is manually set to UIImageOrientationUp which swapped the aspect ratio in
   // some scenarios. For example, when the original image has orientation left, the horizontal
@@ -85,9 +89,9 @@
       [image imageOrientation] == UIImageOrientationRight ||
       [image imageOrientation] == UIImageOrientationLeftMirrored ||
       [image imageOrientation] == UIImageOrientationRightMirrored) {
-    double temp = width;
-    width = height;
-    height = temp;
+    //double temp = width;
+    //width = height;
+    //height = temp;
   }
 
   UIGraphicsBeginImageContextWithOptions(CGSizeMake(width, height), NO, 1.0);
@@ -95,6 +99,7 @@
 
   UIImage *scaledImage = UIGraphicsGetImageFromCurrentImageContext();
   UIGraphicsEndImageContext();
+  
   return scaledImage;
 }
 

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -192,6 +192,7 @@ static const int SOURCE_GALLERY = 1;
   PHAuthorizationStatus status = [PHPhotoLibrary authorizationStatus];
   switch (status) {
     case PHAuthorizationStatusNotDetermined: {
+      
       [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
         if (status == PHAuthorizationStatusAuthorized) {
           dispatch_async(dispatch_get_main_queue(), ^{
@@ -311,26 +312,8 @@ static const int SOURCE_GALLERY = 1;
     if (maxWidth != (id)[NSNull null] || maxHeight != (id)[NSNull null]) {
       image = [FLTImagePickerImageUtil scaledImage:image maxWidth:maxWidth maxHeight:maxHeight];
     }
-
-    PHAsset *originalAsset = [FLTImagePickerPhotoAssetUtil getAssetFromImagePickerInfo:info];
-    if (!originalAsset) {
-      // Image picked without an original asset (e.g. User took a photo directly)
-      [self saveImageWithPickerInfo:info image:image imageQuality:imageQuality];
-    } else {
-      __weak typeof(self) weakSelf = self;
-      [[PHImageManager defaultManager]
-          requestImageDataForAsset:originalAsset
-                           options:nil
-                     resultHandler:^(NSData *_Nullable imageData, NSString *_Nullable dataUTI,
-                                     UIImageOrientation orientation, NSDictionary *_Nullable info) {
-                       // maxWidth and maxHeight are used only for GIF images.
-                       [weakSelf saveImageWithOriginalImageData:imageData
-                                                          image:image
-                                                       maxWidth:maxWidth
-                                                      maxHeight:maxHeight
-                                                   imageQuality:imageQuality];
-                     }];
-    }
+    [self saveImageWithPickerInfo:info image:image imageQuality:imageQuality];
+    
   }
 }
 


### PR DESCRIPTION
A workaround for https://github.com/flutter/flutter/issues/74014

